### PR TITLE
fix autoplay when video is not muted

### DIFF
--- a/snippets/blocks/video-embed.php
+++ b/snippets/blocks/video-embed.php
@@ -9,6 +9,7 @@ $link    = $block->link();
 $controls = $block->controls()->toBool() ? "controls" : "";
 $autoplay = $block->autoplay()->toBool() ? "autoplay" : "";
 $loop     = $block->loop()->toBool()     ? "loop" : "";
+$muted    = $block->autoplay()->toBool() ? "muted" : "";
 
 ?>
 
@@ -19,6 +20,7 @@ $loop     = $block->loop()->toBool()     ? "loop" : "";
             <?= "$controls" ?>
             <?= "$autoplay" ?>
             <?= "$loop" ?>
+            <?= "$muted" ?>
             alt="<?= $alt->esc() ?>">
             <source src="<?= \Kirby\Toolkit\Str::esc($file->url()) ?>" type="video/mp4">
             Your browser does not support the video tag.


### PR DESCRIPTION
In order to autoplay the video must be muted. Here I set that option if autoplay is enabled.