### PR TITLE
Fix width of video preview in panel

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,1 +1,15 @@
-.video-container>figure{display:flex;flex-direction:column;align-items:center;row-gap:.75rem}.video-caption{color:#777}.video-caption-link{text-decoration:underline}
+.video-container > figure{
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    row-gap:.75rem
+}
+.video-container > figure > video {
+    width: 100%;
+}
+.video-caption {
+    color:#777
+}
+.video-caption-link {
+    text-decoration:underline
+}

--- a/src/components/VideoEmbed.vue
+++ b/src/components/VideoEmbed.vue
@@ -45,6 +45,10 @@ const video = computed(() => props.content.video[0])
   row-gap: 0.75rem;
 }
 
+.video-container > figure > video {
+  width: 100%;
+}
+
 .video-caption {
   color: #777777;
 }


### PR DESCRIPTION
Somehow the video preview in the panel wasn’t sized to the width of the column. Instead its placed in original size depending on the video resolution. Have a look at the attached screenshot.

![2024-12-12 Screenshot](https://github.com/user-attachments/assets/18e7ab2c-d5cd-4d48-8bc0-aaa1d7c86c81)

Should be fixed now. :)
Cheers, Simon